### PR TITLE
Use absolute path and rename input spreadsheet tab2

### DIFF
--- a/scripts/QC_metrics.py
+++ b/scripts/QC_metrics.py
@@ -17,7 +17,7 @@ batch_name = os.path.basename(out_dir)
 if not os.path.isdir(out_dir):
     sys.exit("Workflow output dir does not exist: " + out_dir)
 
-in_df = pd.read_excel(in_ss, sheet_name='QC Stats')
+in_df = pd.read_excel(in_ss, sheet_name='QC Metrics')
 lib_list = in_df['SAMPLE ID'].tolist()
 
 hap_scores      = []

--- a/scripts/launcher.pl
+++ b/scripts/launcher.pl
@@ -19,10 +19,12 @@ use Spreadsheet::Read;
 use JSON qw(from_json to_json);
 use IO::File;
 use File::Spec;
+use Cwd 'abs_path';
 
 die "Provide rundir, excel sample spreadsheet, batch name(transfer label) in order" unless @ARGV == 3;
 
 my ($rundir, $sample_sheet, $batch_name) = @ARGV;
+$sample_sheet = abs_path($sample_sheet);
 
 die "$rundir is not valid" unless -d $rundir;
 die "$sample_sheet is not valid" unless -s $sample_sheet;


### PR DESCRIPTION
1. Use absolute path for input spreadsheet so workflow can access to it
2. Rename tab2 of input spreadsheet to "QC Metrics"